### PR TITLE
Allow Configure-Time Selection of which Plugins to Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ option(LLVM_MCAD_ENABLE_TCMALLOC "Enable tcmalloc in gpertools for memory profil
 
 option(LLVM_MCAD_ENABLE_PROFILER "Enable CPU profiler in gpertools" OFF)
 
-option(LLVM_MCAD_BUILD_PLUGINS "Build all MCAD plugins" OFF)
+# See plugins/CMakeLists.txt for LLVM_MCAD_ENABLE_PLUGINS option
 
 # Sanitizers
 option(LLVM_MCAD_ENABLE_ASAN "Enable address sanitizer" OFF)
@@ -122,6 +122,4 @@ target_link_libraries(llvm-mcad
 
 unset(LLVM_LINK_COMPONENTS)
 
-if (LLVM_MCAD_BUILD_PLUGINS)
-  add_subdirectory(plugins)
-endif()
+add_subdirectory(plugins)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ ninja all
 ```
 For instance, if you build `llvm-project` using the previous steps, _"/path/to/installed-llvm/lib/cmake/llvm"_ will be _"/path/to/llvm-project/.build/lib/cmake/llvm"_.
 
-Note that plugins under the `plugins` folder are not built by default. Please add `-DLLVM_MCAD_BUILD_PLUGINS=ON` if you want to build them. Here are some other CMake arguments you can tweak:
+Note that plugins under the `plugins` folder are not built by default. Please add `-DLLVM_MCAD_ENABLE_PLUGINS=all` if you want to build all of them, or give a semicolon-separated list of the choices `qemu`, `tracer`, `binja` or `vivisect` to select specifically which plugins to build. 
+
+Here are some other CMake arguments you can tweak:
  - `LLVM_MCAD_ENABLE_ASAN`. Enable the address sanitizer.
  - `LLVM_MCAD_ENABLE_TCMALLOC`. Uses tcmalloc and its heap profiler.
  - `LLVM_MCAD_ENABLE_PROFILER`. Uses CPU profiler from [gperftools](https://github.com/gperftools/gperftools).

--- a/docker/setup-build.sh
+++ b/docker/setup-build.sh
@@ -10,6 +10,6 @@ cd LLVM-MCA-Daemon/build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/opt/LLVM-MCA-Daemon \
                -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 \
                -DLLVM_DIR=/opt/llvm-14/lib/cmake/llvm \
-               -DLLVM_MCAD_BUILD_PLUGINS=ON \
+               -DLLVM_MCAD_ENABLE_PLUGINS="tracer;binja;vivisect" \
                ../
 ninja

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,25 +1,44 @@
-include(FetchContent)
+set(LLVM_MCAD_ALL_PLUGINS "qemu;tracer;vivisect;binja")
+set(LLVM_MCAD_ENABLE_PLUGINS "" CACHE STRING
+        "Semicolon-separated list of MCAD plugins to build (${LLVM_KNOWN_PROJECTS}), or \"all\". Empty string (default) builds none.")
+if (LLVM_MCAD_ENABLE_PLUGINS STREQUAL "all")
+        set( LLVM_MCAD_ENABLE_PLUGINS ${LLVM_MCAD_ALL_PLUGINS})
+endif()
 
-set(ABSL_ENABLE_INSTALL ON)
-SET(ABSL_PROPAGATE_CXX_STD ON)
-SET(ABSL_BUILD_TESTING OFF)
+if (NOT LLVM_MCAD_ENABLE_PLUGINS STREQUAL "")
 
-FetchContent_Declare(
-  gRPC
-  GIT_REPOSITORY https://github.com/grpc/grpc
-  GIT_TAG        v1.60.0 
-)
-set(FETCHCONTENT_QUIET OFF)
-FetchContent_MakeAvailable(gRPC)
+	include(FetchContent)
 
-include(${grpc_BINARY_DIR}/third_party/protobuf/cmake/protobuf/protobuf-generate.cmake)
+	set(ABSL_ENABLE_INSTALL ON)
+	SET(ABSL_PROPAGATE_CXX_STD ON)
+	SET(ABSL_BUILD_TESTING OFF)
 
-set(grpc_cpp_plugin_location $<TARGET_FILE:grpc_cpp_plugin>)
+	FetchContent_Declare(
+	  gRPC
+	  GIT_REPOSITORY https://github.com/grpc/grpc
+	  GIT_TAG        v1.60.0 
+	)
+	set(FETCHCONTENT_QUIET OFF)
+	FetchContent_MakeAvailable(gRPC)
 
-set(proto_include_dir "${CMAKE_CURRENT_BINARY_DIR}")
-message(STATUS "Protobuf include directory: ${proto_include_dir}")
+	include(${grpc_BINARY_DIR}/third_party/protobuf/cmake/protobuf/protobuf-generate.cmake)
 
-# add_subdirectory(qemu-broker)
-add_subdirectory(tracer-broker)
-add_subdirectory(vivisect-broker)
-add_subdirectory(binja-broker)
+	set(grpc_cpp_plugin_location $<TARGET_FILE:grpc_cpp_plugin>)
+
+	set(proto_include_dir "${CMAKE_CURRENT_BINARY_DIR}")
+	message(STATUS "Protobuf include directory: ${proto_include_dir}")
+
+	if ("qemu" IN_LIST LLVM_MCAD_ENABLE_PLUGINS)
+		add_subdirectory(qemu-broker)
+	endif ()
+	if ("tracer" IN_LIST LLVM_MCAD_ENABLE_PLUGINS)
+		add_subdirectory(tracer-broker)
+	endif ()
+	if ("vivisect" IN_LIST LLVM_MCAD_ENABLE_PLUGINS)
+		add_subdirectory(vivisect-broker)
+	endif ()
+	if ("binja" IN_LIST LLVM_MCAD_ENABLE_PLUGINS)
+		add_subdirectory(binja-broker)
+	endif ()
+
+endif()

--- a/plugins/qemu-broker/README.md
+++ b/plugins/qemu-broker/README.md
@@ -34,7 +34,7 @@ sudo apt install flatbuffers-compiler
 ```
 
 ## Build
-Things in this folder -- including the broker plugin and the QEMU "relay" plugin -- will be built with rest of the LLVM-MCAD project if the `-DLLVM_MCAD_BUILD_PLUGINS=ON` is given when configuring.
+Things in this folder -- including the broker plugin and the QEMU "relay" plugin -- will be built with rest of the LLVM-MCAD project if the `-DLLVM_MCAD_ENABLE_PLUGINS=qemu` is given when configuring.
 
 In addition, you need to supply the QEMU include folder via the `QEMU_INCLUDE_DIR` CMake argument. Here is a complete example:
 ```bash
@@ -42,7 +42,7 @@ cd /path/to/LLVM-MCA-Daemon  # root of this project
 mkdir .build && cd .build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug \
                -DLLVM_DIR=/path/to/installed-llvm/lib/cmake/llvm \
-               -DLLVM_MCAD_BUILD_PLUGINS=ON \
+               -DLLVM_MCAD_ENABLE_PLUGINS=qemu \
                -DQEMU_INCLUDE_DIR=/path/to/qemu/include \
                ../
 ninja all
@@ -51,7 +51,7 @@ If you want to use a custom Flatbuffers, you can use the `CMAKE_PREFIX_PATH` CMa
 ```bash
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug \
                -DLLVM_DIR=/path/to/installed-llvm/lib/cmake/llvm \
-               -DLLVM_MCAD_BUILD_PLUGINS=ON \
+               -DLLVM_MCAD_ENABLE_PLUGINS=qemu \
                -DQEMU_INCLUDE_DIR=/path/to/qemu/include \
                -DCMAKE_PREFIX_PATH=/path/to/your/flatbuffers \
                ../

--- a/plugins/vivisect-broker/README.md
+++ b/plugins/vivisect-broker/README.md
@@ -22,14 +22,14 @@ pip install protobuf
 
 ## Build
 
-To build MCAD plugins you must set `-DLLVM_MCAD_BUILD_PLUGINS=ON` when running
+To build MCAD plugins you must set `-DLLVM_MCAD_ENABLE_PLUGINS=vivisect` when running
 the CMake config step. For example
 
 ```
 mkdir build && build
 cmake -GNinja -DCMAKE_BUILD_TYPE=Debug \
               -DLLVM_DIR=/path/to/installed-llvm/lib/cmake/llvm \
-              -DLLVM_MCAD_BUILD_PLUGINS=ON \
+              -DLLVM_MCAD_ENABLE_PLUGINS=vivisect \
               ..
 ninja llvm-mcad MCADVivisectBroker
 ```


### PR DESCRIPTION
`-DLLVM_MCAD_BUILD_PLUGINS=on`
becomes
`-DLLVM_MCAD_ENABLE_PLUGINS=qemu;vivisect;tracer;binja`

Please double check the docker script, I did not test it