### PR TITLE
Binja: busy-loop waits -> blocking waits

### DIFF
--- a/plugins/binja-broker/Broker.cpp
+++ b/plugins/binja-broker/Broker.cpp
@@ -102,7 +102,7 @@ class RawListener : public mca::HWEventListener {
 public:
     RawListener(BinjaBridge &bridge) : BridgeRef(bridge), CurrentCycle(0U) {}
 
-    void onEvent(const mca::HWInstructionEvent &Event) {
+    void onEvent(const mca::HWInstructionEvent &Event) override {
         const mca::Instruction &inst = *Event.IR.getInstruction();
         const unsigned index = Event.IR.getSourceIndex();
 
@@ -121,11 +121,11 @@ public:
         }
     }
 
-    void onEvent(const mca::HWStallEvent &Event) {
+    void onEvent(const mca::HWStallEvent &Event) override {
         std::cout << "[BINJA] Stall !\n";
     }
 
-    void onEvent(const mca::HWPressureEvent &Event) {
+    void onEvent(const mca::HWPressureEvent &Event) override {
         std::cout << "[BINJA] Pressure !\n";
         for (const auto &inst : Event.AffectedInstructions) {
             const unsigned index = inst.getSourceIndex();
@@ -156,7 +156,7 @@ class BinjaBroker : public Broker {
 
     void serverLoop();
 
-    void signalWorkerComplete() {
+    void signalWorkerComplete() override {
         Bridge.IsWaitingForWorker.store(false);
         Bridge.IsWaitingForWorker.notify_one();
     }

--- a/plugins/binja-broker/Broker.cpp
+++ b/plugins/binja-broker/Broker.cpp
@@ -149,7 +149,7 @@ class BinjaBroker : public Broker {
     std::vector<std::unique_ptr<MCInst>> Local_MCIS;
     const std::string ListenAddr, ListenPort;
 
-    std::unique_ptr<std::jthread> ServerThread;
+    std::unique_ptr<std::thread> ServerThread;
     std::unique_ptr<grpc::Server> server;
 
     void serverLoop();
@@ -236,7 +236,7 @@ public:
           Ctx(C), 
           STI(MSTI), 
           Bridge(BinjaBridge()) {
-        ServerThread = std::make_unique<std::jthread>(&BinjaBroker::serverLoop, this);
+        ServerThread = std::make_unique<std::thread>(&BinjaBroker::serverLoop, this);
         DisAsm.reset(TheTarget.createMCDisassembler(STI, Ctx));
         Listener = std::make_unique<RawListener>(Bridge);
     }

--- a/plugins/binja-broker/Broker.cpp
+++ b/plugins/binja-broker/Broker.cpp
@@ -62,7 +62,7 @@ class BinjaBridge final : public Binja::Service {
             for (int i = 0; i < insns->instruction_size(); i++) {
                 InsnQueue.push(insns->instruction(i));
             }
-            HasHandledInput.store(false);
+            DoneHandlingInput.store(false);
         }
 
         IsWaitingForWorker.store(true);
@@ -78,7 +78,7 @@ class BinjaBridge final : public Binja::Service {
             cc->set_is_under_pressure(CountStore[i].IsUnderPressure);
         }
 
-        HasHandledInput.store(true);
+        DoneHandlingInput.store(true);
 
         return grpc::Status::OK;
     }
@@ -89,7 +89,7 @@ public:
     std::queue<BinjaInstructions::Instruction> InsnQueue;
     std::mutex QueueMutex;
     std::atomic<bool> IsWaitingForWorker = false;
-    std::atomic<bool> HasHandledInput = true;
+    std::atomic<bool> DoneHandlingInput = true;
     DenseMap<unsigned, InstructionEntry> CountStore;
 };
 
@@ -173,7 +173,7 @@ class BinjaBroker : public Broker {
                     return std::make_pair(-1, RegionDescriptor(true));
                 }
 
-                if (Bridge.HasHandledInput.load()) {
+                if (Bridge.DoneHandlingInput.load()) {
                     return std::make_pair(0, RegionDescriptor(false));
                 }
 

--- a/plugins/binja-broker/CMakeLists.txt
+++ b/plugins/binja-broker/CMakeLists.txt
@@ -4,9 +4,9 @@ add_library(binja_bridge_proto binja.proto)
 target_compile_options(binja_bridge_proto PRIVATE "-fPIC")
 target_link_libraries(binja_bridge_proto
     PUBLIC
-        libprotobuf
-        grpc
+        grpc++_reflection
         grpc++
+        libprotobuf
 )
 
 # Compile protobuf and grpc files in binja_bridge_proto target to cpp
@@ -39,8 +39,19 @@ add_llvm_library(MCADBinjaBroker SHARED
 add_dependencies(MCADBinjaBroker 
     binja_bridge_proto)
 
+# MacOS-specific fix:
+# The mcadGetBrokerPluginInfo() function, which is defined by the individual
+# plugins, calls into functions defined in the main llvm-mcad executable into
+# which the plugin will be loaded at runtime. We cannot link against the main
+# executable; instead those calls should be resolved at runtime. We achieve this
+# on Linux using attribute(weak) in the source code; the MacOS linker requires
+# -undefied dynamic_lookup as a command line argument.
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  target_link_options(MCADBinjaBroker PUBLIC -Wl,-undefined -Wl,dynamic_lookup)
+endif()
+
 target_link_libraries(MCADBinjaBroker PUBLIC binja_bridge_proto)
 
 unset(LLVM_EXPORTED_SYMBOL_FILE)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})

--- a/plugins/binja-broker/README.md
+++ b/plugins/binja-broker/README.md
@@ -41,7 +41,29 @@ To install the plugin, the easiest way is to create a symlink of the `binja-plug
 ln -s binja-plugin ~/.binaryninja/plugins/mcad
 ```
 
+On MacOS, you have to fully copy the conents:
+```
+cp -r binja-plugin "~/Library/Application Support/Binary Ninja"
+```
+
 Update variable `MCAD_BUILD_PATH` in `MCADBridge.py` to point to your build directory. For instance, `/home/chinmay_dd/Projects/LLVM-MCA-Daemon/build`. It will pick up `llvm-mcad` from there.
+
+The Python interpreter used by Binary Ninja will have to have access to the PIP packages `grpcio` and `protobuf`.
+The easiest way to set this up cleanly is with a separate Binary-Ninja Python virtual environment:
+
+```
+cd ~
+python3 -m venv binja_venv
+source binja_venv/bin/activate
+pip3 install grpcio protobuf
+```
+
+Then, in the Binary Ninja settings, under Python, set
+```
+python.binaryOverride = /path/to/binja_venv/bin/python3
+python.interpreter = /path/to/binja_venv/bin/python3
+python.virtualenv = /path/to/binja_venv/lib/python3.12/site-packages
+```
 
 ### Usage
 


### PR DESCRIPTION
@chinmaydd I haven't been able to test this yet since I don't have binary ninja yet.

At least superficially it seems to work though, everything is blocked at a syscall after startup instead of idling:

![image](https://github.com/securesystemslab/LLVM-MCA-Daemon/assets/557998/44646283-8caf-443e-9648-7978b470404e)
