### PR TITLE
do not rely on leaked pointer to deallocated object

### DIFF
--- a/plugins/vivisect-broker/Broker.cpp
+++ b/plugins/vivisect-broker/Broker.cpp
@@ -74,6 +74,7 @@ class VivisectBroker : public Broker {
 
   std::unique_ptr<std::thread> ServerThread;
   std::unique_ptr<grpc::Server> server;
+  std::vector<MCInst> MCI_Pool;
 
   void serverLoop();
 
@@ -114,11 +115,15 @@ class VivisectBroker : public Broker {
             }
             ArrayRef<uint8_t> InstBytes(instructionBuffer);
 
-            auto MCI = std::make_shared<MCInst>();
+            // Create new MCInst and put it into our local pool storage.
+            // This can be freed when the worker thread is done with it.
+            MCI_Pool.emplace_back();
+            MCInst &MCI = MCI_Pool.back();
             uint64_t DisAsmSize;
-            auto Disassembled = DisAsm->getInstruction(*MCI, DisAsmSize, InstBytes, 0, nulls());
+            auto Disassembled = DisAsm->getInstruction(MCI, DisAsmSize, InstBytes, 0, nulls());
+            assert(Disassembled == MCDisassembler::DecodeStatus::Success);
 
-            MCIS[i] = MCI.get();
+            MCIS[i] = &MCI;  // return a pointer into our MCI_Pool
 
             if (MDE && insn.has_memory_access()) {
                 auto MemAccess = insn.memory_access();
@@ -147,6 +152,10 @@ class VivisectBroker : public Broker {
         }
         return std::make_pair(num_insn, RegionDescriptor(false));
     }
+  }
+
+  void signalWorkerComplete() override {
+    MCI_Pool.clear();
   }
 
     unsigned getFeatures() const override {


### PR DESCRIPTION
The vivisect plugin was broken for me.

Context: In MCAD, there is a worker thread that consumes instructions from a queue and calculates cycle counts for each of them, and there is a broker plugin that adds instructions to that queue. The `fetchRegion` function is a function in the broker plugin that adds instructions to the queue.

The vivisect implementation of that function created an `MCInst` object (== an instruction) within its local scope, then returned a pointer to that object to the caller (worker thread). Once the object went out of scope, it was deallocated, but the caller (worker thread) still used the pointer to read from the stale object.

Fix (not elegant but works without being too intrusive):
 - Create an `MCI_Pool` that keeps the `MCInst` objects inside a vector which is scoped to live as long as the vivisect Broker plugin. `fetchRegion` creates objects into the `MCI_Pool` and returns pointers to it.
 - To avoid monotonically increasing memory consumption (i.e. a leak), use the `signalWorkerComplete` callback to remove objects from the `MCI_Pool` once the worker is done with them.