### PR TITLE
Make MCAD compile with upstream LLVM as of 78ccffc05336201c90

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 *.pyc
 compile_commands.json
 .cache/
+.vscode/
+.venv/

--- a/Brokers/AsmUtils/CodeRegionGenerator.cpp
+++ b/Brokers/AsmUtils/CodeRegionGenerator.cpp
@@ -58,10 +58,11 @@ public:
     return true;
   }
 
-  void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size, Align Alignment) {}
+  void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size, Align Alignment)
+                       override {}
   void emitZerofill(MCSection *Section, MCSymbol *Symbol = nullptr,
                     uint64_t Size = 0, Align ByteAlignment = Align(1),
-                    SMLoc Loc = SMLoc()) {}
+                    SMLoc Loc = SMLoc()) override {}
   void emitGPRel32Value(const MCExpr *Value) override {}
   void BeginCOFFSymbolDef(const MCSymbol *Symbol) {}
   void EmitCOFFSymbolStorageClass(int StorageClass) {}
@@ -122,8 +123,7 @@ Expected<const CodeRegions &> AsmCodeRegionGenerator::parseCodeRegions() {
   // The following call will take care of calling Streamer.setTargetStreamer.
   MCStreamerWrapper Streamer(Ctx, Regions);
   TheTarget.createAsmTargetStreamer(Streamer, InstPrinterOStream,
-                                         InstPrinter.get(),
-                                         Opts.AsmVerbose);
+                                         InstPrinter.get());
   if (!Streamer.getTargetStreamer())
     return make_error<StringError>("cannot create target asm streamer", inconvertibleErrorCode());
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You only need one additional CMake argument: `LLVM_DIR`. This should point to LL
 ```bash
 mkdir .build && cd .build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug \
-               -DLLVM_DIR=$(realpath ../install)/lib/cmake/llvm \
+               -DLLVM_DIR=$(realpath ../llvm-project/install)/lib/cmake/llvm \
                ../
 ninja all
 ```

--- a/plugins/vivisect-broker/CMakeLists.txt
+++ b/plugins/vivisect-broker/CMakeLists.txt
@@ -4,9 +4,9 @@ add_library(vivisect_service_proto emulator.proto)
 target_compile_options(vivisect_service_proto PRIVATE "-fPIC")
 target_link_libraries(vivisect_service_proto
     PUBLIC
-        libprotobuf
-        grpc
+        grpc++_reflection
         grpc++
+        libprotobuf
 )
 
 # Compile protobuf and grpc files in vivisect_service_proto target to cpp
@@ -38,8 +38,19 @@ add_llvm_library(MCADVivisectBroker SHARED
 add_dependencies(MCADVivisectBroker 
     vivisect_service_proto)
 
+# MacOS-specific fix:
+# The mcadGetBrokerPluginInfo() function, which is defined by the individual
+# plugins, calls into functions defined in the main llvm-mcad executable into
+# which the plugin will be loaded at runtime. We cannot link against the main
+# executable; instead those calls should be resolved at runtime. We achieve this
+# on Linux using attribute(weak) in the source code; the MacOS linker requires
+# -undefied dynamic_lookup as a command line argument.
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  target_link_options(MCADVivisectBroker PUBLIC -Wl,-undefined -Wl,dynamic_lookup)
+endif()
+
 target_link_libraries(MCADVivisectBroker PUBLIC vivisect_service_proto)
 
 unset(LLVM_EXPORTED_SYMBOL_FILE)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})

--- a/plugins/vivisect-broker/README.md
+++ b/plugins/vivisect-broker/README.md
@@ -16,8 +16,8 @@ protoc --grpc_out=. --cpp_out=. --plugin=protoc-gen-grpc=`which grpc_cpp_plugin`
 This may require running the following if they are not already installed on your system
 
 ```
-pip install grpcio
-pip install protobuf
+sudo apt install -y protobuf-compiler python3-dev
+pip install grpcio grpcio-tools protobuf
 ```
 
 ## Build


### PR DESCRIPTION
- Minor changes required to get it to compile after LLVM changes and to squash warnings.
- Merge in changes from `broker-improvements` to keep `main` up to speed (#18, #19, #20)

Still currently crashes at run-time with the following output -- this seems directly related to the same issues Chinmay was having (see Slack) where something in LLVM relies on the default `LSUnit` instead of our subclassed `MCADLSUnit`:

```
Assertion failed: (Value.isa<T>() && "Bad any cast!"), function any_cast, file Any.h, line 139.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: ./llvm-mcad -mtriple=powerpcle-linux-gnu -mcpu=e500 -debug -load-broker-plugin=/Users/andreroesti/Documents/mcad/LLVM-MCA-Daemon/build-using-upstream-llvm/plugins/vivisect-broker/libMCADVivisectBroker.dylib
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  libLLVMSupport.dylib     0x000000010b80ec2d llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 61
1  libLLVMSupport.dylib     0x000000010b80f1eb PrintStackTraceSignalHandler(void*) + 27
2  libLLVMSupport.dylib     0x000000010b80cc76 llvm::sys::RunSignalHandlers() + 134
3  libLLVMSupport.dylib     0x000000010b81037f SignalHandler(int) + 223
4  libsystem_platform.dylib 0x00007ff810239fdd _sigtramp + 29
5  libLLVMSupport.dylib     0x000000010b7dc94c llvm::raw_ostream::write(char const*, unsigned long) + 108
6  libsystem_c.dylib        0x00007ff810130a79 abort + 126
7  libsystem_c.dylib        0x00007ff81012fd68 err + 0
8  llvm-mcad                0x000000010796f244 llvm::mcad::MDMemoryAccess llvm::any_cast<llvm::mcad::MDMemoryAccess>(llvm::Any const&) + 116
9  llvm-mcad                0x0000000107965d7a std::__1::optional<llvm::mcad::MDMemoryAccess> llvm::mcad::MetadataCategory::get<llvm::mcad::MDMemoryAccess>(unsigned int) const + 138
10 llvm-mcad                0x0000000107965cd3 llvm::mcad::MCADLSUnit::getMemoryAccessMD(llvm::mca::InstRef const&) const + 163
11 llvm-mcad                0x0000000107967236 llvm::mcad::MCADLSUnit::isAvailable(llvm::mca::InstRef const&) const + 54
12 libLLVMMCA.dylib         0x0000000108ae12de llvm::mca::Scheduler::isAvailable(llvm::mca::InstRef const&) + 190
13 libLLVMMCA.dylib         0x0000000108b064f5 llvm::mca::ExecuteStage::isAvailable(llvm::mca::InstRef const&) const + 37
14 libLLVMMCA.dylib         0x0000000108b0158a llvm::mca::Stage::checkNextStage(llvm::mca::InstRef const&) const + 58
15 libLLVMMCA.dylib         0x0000000108b0151a llvm::mca::DispatchStage::canDispatch(llvm::mca::InstRef const&) const + 90
16 libLLVMMCA.dylib         0x0000000108b01f7f llvm::mca::DispatchStage::isAvailable(llvm::mca::InstRef const&) const + 175
17 libLLVMMCA.dylib         0x0000000108b0158a llvm::mca::Stage::checkNextStage(llvm::mca::InstRef const&) const + 58
18 libLLVMMCA.dylib         0x0000000108b02b5e llvm::mca::EntryStage::isAvailable(llvm::mca::InstRef const&) const + 62
19 libLLVMMCA.dylib         0x0000000108afeae0 llvm::mca::Pipeline::runCycle() + 480
20 libLLVMMCA.dylib         0x0000000108afe758 llvm::mca::Pipeline::run() + 168
21 llvm-mcad                0x000000010797f215 llvm::mcad::MCAWorker::runPipeline() + 325
22 llvm-mcad                0x000000010797dfbf llvm::mcad::MCAWorker::run() + 3375
23 llvm-mcad                0x0000000107933e83 main + 3795
24 dyld                     0x00007ff80fe7f366 start + 1942
zsh: abort      ./llvm-mcad -mtriple="powerpcle-linux-gnu" -mcpu="e500" -debug 
```