### PR TITLE
Use subclassed MemoryGroups and LSUnit

### DIFF
--- a/CustomHWUnits/MCADLSUnit.cpp
+++ b/CustomHWUnits/MCADLSUnit.cpp
@@ -261,9 +261,12 @@ void MCADLSUnit::onInstructionExecuted(const mca::InstRef &IR) {
   const mca::Instruction &IS = *IR.getInstruction();
   if (!IS.isMemOp())
     return;
-
-  LSUnitBase::onInstructionExecuted(IR);
   unsigned GroupID = IS.getLSUTokenID();
+  auto It = CustomGroups.find(GroupID);
+  assert(It != CustomGroups.end() && "Instruction not dispatched to the LS unit");
+  It->second->onInstructionExecuted(IR);
+  if (It->second->isExecuted())
+    CustomGroups.erase(It);
   if (!isValidGroupID(GroupID)) {
     if (GroupID == CurrentLoadGroupID)
       CurrentLoadGroupID = 0;

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ git am < ../LLVM-MCA-Daemon/patches/add-identifier-to-mca-instruction.patch
 git am < ../LLVM-MCA-Daemon/patches/start-mapping-e500-itenerary-model-to-new-schedule.patch
 # Patch to make `Any` data type work across shared libraries
 git am < /work/LLVM-MCA-Daemon/patches/make-any-work-across-shared-libs.patch
+# Patch to make `MemoryGroups` and `LSUnit` subclassable
+git am < /work/LLVM-MCA-Daemon/patches/abstract-memory-group.patch
 mkdir install
 mkdir .build && cd .build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug \

--- a/docker/setup-llvm.sh
+++ b/docker/setup-llvm.sh
@@ -25,6 +25,7 @@ cd llvm
 git am < /work/LLVM-MCA-Daemon/patches/add-identifier-to-mca-instruction.patch
 git am < /work/LLVM-MCA-Daemon/patches/start-mapping-e500-itenerary-model-to-new-schedule.patch
 git am < /work/LLVM-MCA-Daemon/patches/make-any-work-across-shared-libs.patch
+git am < /work/LLVM-MCA-Daemon/patches/abstract-memory-group.patch
 mkdir build && cd build
 cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/opt/llvm-main \
                -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 \

--- a/patches/abstract-memory-group.patch
+++ b/patches/abstract-memory-group.patch
@@ -1,0 +1,222 @@
+From de6fe5b96962318a8195b99076ff46380b2fe2a0 Mon Sep 17 00:00:00 2001
+From: andreroesti <an.roesti@gmail.com>
+Date: Fri, 18 Oct 2024 15:47:20 -0700
+Subject: [PATCH] make minimal set of methods of MemoryGroups abstract to make
+ subclassing LSUnit work
+
+---
+ llvm/include/llvm/MCA/HardwareUnits/LSUnit.h | 35 ++++++++++++--------
+ llvm/lib/MCA/HardwareUnits/LSUnit.cpp        | 21 ++++++------
+ llvm/lib/MCA/HardwareUnits/Scheduler.cpp     |  2 +-
+ 3 files changed, 33 insertions(+), 25 deletions(-)
+
+diff --git a/llvm/include/llvm/MCA/HardwareUnits/LSUnit.h b/llvm/include/llvm/MCA/HardwareUnits/LSUnit.h
+index 81a5453bac26..f102509b7dc1 100644
+--- a/llvm/include/llvm/MCA/HardwareUnits/LSUnit.h
++++ b/llvm/include/llvm/MCA/HardwareUnits/LSUnit.h
+@@ -24,6 +24,13 @@
+ namespace llvm {
+ namespace mca {
+ 
++class AbstractMemoryGroup {
++public:
++  virtual ~AbstractMemoryGroup() {};
++  virtual const CriticalDependency &getCriticalPredecessor() const = 0;
++  virtual bool isExecuting() const = 0; 
++};
++
+ /// A node of a memory dependency graph. A MemoryGroup describes a set of
+ /// instructions with same memory dependencies.
+ ///
+@@ -32,7 +39,7 @@ namespace mca {
+ /// A Memory group identifier is then stored as a "token" in field
+ /// Instruction::LSUTokenID of each dispatched instructions. That token is used
+ /// internally by the LSUnit to track memory dependencies.
+-class MemoryGroup {
++class MemoryGroup : public AbstractMemoryGroup {
+   unsigned NumPredecessors = 0;
+   unsigned NumExecutingPredecessors = 0;
+   unsigned NumExecutedPredecessors = 0;
+@@ -72,7 +79,7 @@ public:
+   const InstRef &getCriticalMemoryInstruction() const {
+     return CriticalMemoryInstruction;
+   }
+-  const CriticalDependency &getCriticalPredecessor() const {
++  const CriticalDependency &getCriticalPredecessor() const override {
+     return CriticalPredecessor;
+   }
+ 
+@@ -104,7 +111,7 @@ public:
+             NumPredecessors);
+   }
+   bool isReady() const { return NumExecutedPredecessors == NumPredecessors; }
+-  bool isExecuting() const {
++  bool isExecuting() const override {
+     return NumExecuting && (NumExecuting == (NumInstructions - NumExecuted));
+   }
+   bool isExecuted() const { return NumInstructions == NumExecuted; }
+@@ -265,45 +272,45 @@ public:
+   bool isSQFull() const { return SQSize && SQSize == UsedSQEntries; }
+   bool isLQFull() const { return LQSize && LQSize == UsedLQEntries; }
+ 
+-  bool isValidGroupID(unsigned Index) const {
++  virtual bool isValidGroupID(unsigned Index) const {
+     return Index && Groups.contains(Index);
+   }
+ 
+   /// Check if a peviously dispatched instruction IR is now ready for execution.
+-  bool isReady(const InstRef &IR) const {
++  virtual bool isReady(const InstRef &IR) const {
+     unsigned GroupID = IR.getInstruction()->getLSUTokenID();
+-    const MemoryGroup &Group = getGroup(GroupID);
++    const MemoryGroup &Group = static_cast<const MemoryGroup&>(getGroup(GroupID));
+     return Group.isReady();
+   }
+ 
+   /// Check if instruction IR only depends on memory instructions that are
+   /// currently executing.
+-  bool isPending(const InstRef &IR) const {
++  virtual bool isPending(const InstRef &IR) const {
+     unsigned GroupID = IR.getInstruction()->getLSUTokenID();
+-    const MemoryGroup &Group = getGroup(GroupID);
++    const MemoryGroup &Group = static_cast<const MemoryGroup&>(getGroup(GroupID));
+     return Group.isPending();
+   }
+ 
+   /// Check if instruction IR is still waiting on memory operations, and the
+   /// wait time is still unknown.
+-  bool isWaiting(const InstRef &IR) const {
++  virtual bool isWaiting(const InstRef &IR) const {
+     unsigned GroupID = IR.getInstruction()->getLSUTokenID();
+-    const MemoryGroup &Group = getGroup(GroupID);
++    const MemoryGroup &Group = static_cast<const MemoryGroup&>(getGroup(GroupID));
+     return Group.isWaiting();
+   }
+ 
+-  bool hasDependentUsers(const InstRef &IR) const {
++  virtual bool hasDependentUsers(const InstRef &IR) const {
+     unsigned GroupID = IR.getInstruction()->getLSUTokenID();
+-    const MemoryGroup &Group = getGroup(GroupID);
++    const MemoryGroup &Group = static_cast<const MemoryGroup&>(getGroup(GroupID));
+     return !Group.isExecuted() && Group.getNumSuccessors();
+   }
+ 
+-  const MemoryGroup &getGroup(unsigned Index) const {
++  virtual const AbstractMemoryGroup &getGroup(unsigned Index) const {
+     assert(isValidGroupID(Index) && "Group doesn't exist!");
+     return *Groups.find(Index)->second;
+   }
+ 
+-  MemoryGroup &getGroup(unsigned Index) {
++  virtual AbstractMemoryGroup &getGroup(unsigned Index) {
+     assert(isValidGroupID(Index) && "Group doesn't exist!");
+     return *Groups.find(Index)->second;
+   }
+diff --git a/llvm/lib/MCA/HardwareUnits/LSUnit.cpp b/llvm/lib/MCA/HardwareUnits/LSUnit.cpp
+index bdc8b3d0e390..c61f23f31010 100644
+--- a/llvm/lib/MCA/HardwareUnits/LSUnit.cpp
++++ b/llvm/lib/MCA/HardwareUnits/LSUnit.cpp
+@@ -79,14 +79,14 @@ unsigned LSUnit::dispatch(const InstRef &IR) {
+ 
+   if (IS.getMayStore()) {
+     unsigned NewGID = createMemoryGroup();
+-    MemoryGroup &NewGroup = getGroup(NewGID);
++    MemoryGroup &NewGroup = static_cast<MemoryGroup&>(getGroup(NewGID));
+     NewGroup.addInstruction();
+ 
+     // A store may not pass a previous load or load barrier.
+     unsigned ImmediateLoadDominator =
+         std::max(CurrentLoadGroupID, CurrentLoadBarrierGroupID);
+     if (ImmediateLoadDominator) {
+-      MemoryGroup &IDom = getGroup(ImmediateLoadDominator);
++      MemoryGroup &IDom = static_cast<MemoryGroup&>(getGroup(ImmediateLoadDominator));
+       LLVM_DEBUG(dbgs() << "[LSUnit]: GROUP DEP: (" << ImmediateLoadDominator
+                         << ") --> (" << NewGID << ")\n");
+       IDom.addSuccessor(&NewGroup, !assumeNoAlias());
+@@ -94,7 +94,7 @@ unsigned LSUnit::dispatch(const InstRef &IR) {
+ 
+     // A store may not pass a previous store barrier.
+     if (CurrentStoreBarrierGroupID) {
+-      MemoryGroup &StoreGroup = getGroup(CurrentStoreBarrierGroupID);
++      MemoryGroup &StoreGroup = static_cast<MemoryGroup&>(getGroup(CurrentStoreBarrierGroupID));
+       LLVM_DEBUG(dbgs() << "[LSUnit]: GROUP DEP: ("
+                         << CurrentStoreBarrierGroupID
+                         << ") --> (" << NewGID << ")\n");
+@@ -104,7 +104,7 @@ unsigned LSUnit::dispatch(const InstRef &IR) {
+     // A store may not pass a previous store.
+     if (CurrentStoreGroupID &&
+         (CurrentStoreGroupID != CurrentStoreBarrierGroupID)) {
+-      MemoryGroup &StoreGroup = getGroup(CurrentStoreGroupID);
++      MemoryGroup &StoreGroup = static_cast<MemoryGroup&>(getGroup(CurrentStoreGroupID));
+       LLVM_DEBUG(dbgs() << "[LSUnit]: GROUP DEP: (" << CurrentStoreGroupID
+                         << ") --> (" << NewGID << ")\n");
+       StoreGroup.addSuccessor(&NewGroup, !assumeNoAlias());
+@@ -141,21 +141,22 @@ unsigned LSUnit::dispatch(const InstRef &IR) {
+   // 5) There is no intervening store and there is an active load group.
+   //    However that group has already started execution, so we cannot add
+   //    this load to it.
++  MemoryGroup &TheGroup = static_cast<MemoryGroup&>(getGroup(ImmediateLoadDominator));
+   bool ShouldCreateANewGroup =
+       IsLoadBarrier || !ImmediateLoadDominator ||
+       CurrentLoadBarrierGroupID == ImmediateLoadDominator ||
+       ImmediateLoadDominator <= CurrentStoreGroupID ||
+-      getGroup(ImmediateLoadDominator).isExecuting();
++      TheGroup.isExecuting();
+ 
+   if (ShouldCreateANewGroup) {
+     unsigned NewGID = createMemoryGroup();
+-    MemoryGroup &NewGroup = getGroup(NewGID);
++    MemoryGroup &NewGroup = static_cast<MemoryGroup&>(getGroup(NewGID));
+     NewGroup.addInstruction();
+ 
+     // A load may not pass a previous store or store barrier
+     // unless flag 'NoAlias' is set.
+     if (!assumeNoAlias() && CurrentStoreGroupID) {
+-      MemoryGroup &StoreGroup = getGroup(CurrentStoreGroupID);
++      MemoryGroup &StoreGroup = static_cast<MemoryGroup&>(getGroup(CurrentStoreGroupID));
+       LLVM_DEBUG(dbgs() << "[LSUnit]: GROUP DEP: (" << CurrentStoreGroupID
+                         << ") --> (" << NewGID << ")\n");
+       StoreGroup.addSuccessor(&NewGroup, true);
+@@ -164,7 +165,7 @@ unsigned LSUnit::dispatch(const InstRef &IR) {
+     // A load barrier may not pass a previous load or load barrier.
+     if (IsLoadBarrier) {
+       if (ImmediateLoadDominator) {
+-        MemoryGroup &LoadGroup = getGroup(ImmediateLoadDominator);
++        MemoryGroup &LoadGroup = static_cast<MemoryGroup&>(getGroup(ImmediateLoadDominator));
+         LLVM_DEBUG(dbgs() << "[LSUnit]: GROUP DEP: ("
+                           << ImmediateLoadDominator
+                           << ") --> (" << NewGID << ")\n");
+@@ -173,7 +174,7 @@ unsigned LSUnit::dispatch(const InstRef &IR) {
+     } else {
+       // A younger load cannot pass a older load barrier.
+       if (CurrentLoadBarrierGroupID) {
+-        MemoryGroup &LoadGroup = getGroup(CurrentLoadBarrierGroupID);
++        MemoryGroup &LoadGroup = static_cast<MemoryGroup&>(getGroup(CurrentLoadBarrierGroupID));
+         LLVM_DEBUG(dbgs() << "[LSUnit]: GROUP DEP: ("
+                           << CurrentLoadBarrierGroupID
+                           << ") --> (" << NewGID << ")\n");
+@@ -188,7 +189,7 @@ unsigned LSUnit::dispatch(const InstRef &IR) {
+   }
+ 
+   // A load may pass a previous load.
+-  MemoryGroup &Group = getGroup(CurrentLoadGroupID);
++  MemoryGroup &Group = static_cast<MemoryGroup&>(getGroup(CurrentLoadGroupID));
+   Group.addInstruction();
+   return CurrentLoadGroupID;
+ }
+diff --git a/llvm/lib/MCA/HardwareUnits/Scheduler.cpp b/llvm/lib/MCA/HardwareUnits/Scheduler.cpp
+index a9bbf6979919..2b19a4a2e017 100644
+--- a/llvm/lib/MCA/HardwareUnits/Scheduler.cpp
++++ b/llvm/lib/MCA/HardwareUnits/Scheduler.cpp
+@@ -85,7 +85,7 @@ void Scheduler::issueInstructionImpl(
+ 
+   if (IS->isMemOp()) {
+     LSU.onInstructionIssued(IR);
+-    const MemoryGroup &Group = LSU.getGroup(IS->getLSUTokenID());
++    const AbstractMemoryGroup &Group = LSU.getGroup(IS->getLSUTokenID());
+     IS->setCriticalMemDep(Group.getCriticalPredecessor());
+   }
+ 
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
First working version using upstream LLVM

The set of patches to LLVM is the minimal set I needed to apply to make everything run without crashing. There's a lot of room for improvement to make this prettier and actually make sense.