### PR TITLE
Add `FetchDelay` stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,10 @@ set(_CUSTOMHW_SOURCE_FILES
     CustomHWUnits/MCADLSUnit.cpp
    )
 
+set(_CUSTOM_STAGES_SOURCE_FILES
+    CustomStages/MCADFetchDelayStage.cpp
+   )
+
 set(_BROKERS_SOURCE_FILES
     Brokers/BrokerPlugin.cpp
     Brokers/RawBytesBroker.cpp
@@ -111,6 +115,7 @@ set(_SOURCE_FILES
     llvm-mcad.cpp
     ${_MCAVIEWS_SOURCE_FILES}
     ${_CUSTOMHW_SOURCE_FILES}
+    ${_CUSTOM_STAGES_SOURCE_FILES}
     ${_BROKERS_SOURCE_FILES}
     MCAWorker.cpp
     PipelinePrinter.cpp

--- a/CustomStages/MCADFetchDelayStage.cpp
+++ b/CustomStages/MCADFetchDelayStage.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include "CustomStages/MCADFetchDelayStage.h"
+
+namespace llvm {
+namespace mcad {
+
+struct MCADInstructionFetchedEvent {};
+
+bool MCADFetchDelayStage::hasWorkToComplete() const {
+    return !instrQueue.empty();
+}
+
+bool MCADFetchDelayStage::isAvailable(const llvm::mca::InstRef &IR) const {
+    return checkNextStage(IR);
+}
+
+llvm::Error MCADFetchDelayStage::forwardDueInstrs() {
+    while(!instrQueue.empty() && instrQueue.front().delayCyclesLeft == 0) {
+        llvm::mca::InstRef IR = instrQueue.front().IR;
+        if (llvm::Error Val = moveToTheNextStage(IR)) {
+            return Val;
+        }
+        instrQueue.pop_front();
+    }
+    return llvm::ErrorSuccess();
+}
+
+llvm::Error MCADFetchDelayStage::execute(llvm::mca::InstRef &IR) {
+    notifyEvent<llvm::mca::HWInstructionEvent>(llvm::mca::HWInstructionEvent(llvm::mca::HWInstructionEvent::LastGenericEventType, IR));
+    const llvm::mca::Instruction *I = IR.getInstruction();
+    const llvm::mca::InstrDesc &ID = I->getDesc();
+    const llvm::MCInstrDesc &MCID = MCII.get(I->getOpcode());
+    bool immediatelyExecute = true;
+    unsigned delayCyclesLeft = 0;
+    if(MCID.isBranch()) {
+        // delayed, will have to wait
+        delayCyclesLeft = 100;
+    }
+    instrQueue.emplace_back(DelayedInstr { delayCyclesLeft, IR });
+    // if the instruction is not delayed, execute it immediately (it will
+    // have a delayCyclesLeft of 0 and be at the top of the queue)
+    return forwardDueInstrs();
+}
+
+llvm::Error MCADFetchDelayStage::cycleStart() {
+    if(!instrQueue.empty()) {
+        instrQueue.front().delayCyclesLeft--;
+    }
+    return forwardDueInstrs();
+}
+
+}
+}

--- a/CustomStages/MCADFetchDelayStage.cpp
+++ b/CustomStages/MCADFetchDelayStage.cpp
@@ -26,6 +26,8 @@ llvm::Error MCADFetchDelayStage::forwardDueInstrs() {
 }
 
 llvm::Error MCADFetchDelayStage::execute(llvm::mca::InstRef &IR) {
+    // We (ab-)use the LastGenericEventType to create a notification when the instruction first enters this stage.
+    // We use this elsewhere to calculate the number of cycles between when an instruction first enters the pipeline and the end of its execution.
     notifyEvent<llvm::mca::HWInstructionEvent>(llvm::mca::HWInstructionEvent(llvm::mca::HWInstructionEvent::LastGenericEventType, IR));
     const llvm::mca::Instruction *I = IR.getInstruction();
     const llvm::mca::InstrDesc &ID = I->getDesc();

--- a/CustomStages/MCADFetchDelayStage.h
+++ b/CustomStages/MCADFetchDelayStage.h
@@ -1,0 +1,50 @@
+// This class does not model a real hardware stage. It is used to block the
+// pipeline for a number of cycles to prevent further instructions from being
+// fetched. We use this to model the cost of branch mispredictions.
+
+#ifndef LLVM_MCAD_FETCH_DELAY_STAGE_H
+#define LLVM_MCAD_FETCH_DELAY_STAGE_H
+
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MCA/SourceMgr.h"
+#include "llvm/MCA/Stages/Stage.h"
+
+#include <vector>
+#include <queue>
+
+namespace llvm {
+namespace mcad {
+
+class MCADFetchDelayStage : public llvm::mca::Stage {
+
+    struct DelayedInstr {
+        unsigned delayCyclesLeft;
+        llvm::mca::InstRef IR;
+    };
+
+    const llvm::MCInstrInfo &MCII;
+    std::deque<DelayedInstr> instrQueue = {};
+
+public:
+    MCADFetchDelayStage(const llvm::MCInstrInfo &MCII) : MCII(MCII) {}
+
+    bool hasWorkToComplete() const override;
+    bool isAvailable(const llvm::mca::InstRef &IR) const override;
+    llvm::Error execute(llvm::mca::InstRef &IR) override;
+
+    //llvm::Error cycleStart() override;
+    llvm::Error cycleStart() override;
+
+    llvm::Error forwardDueInstrs();
+
+    ///// Called after the pipeline is resumed from pausing state.
+    //virtual Error cycleResume() { return ErrorSuccess(); }
+
+    ///// Called once at the end of each cycle.
+
+};
+
+}
+}
+
+#endif

--- a/plugins/binja-broker/Broker.cpp
+++ b/plugins/binja-broker/Broker.cpp
@@ -150,7 +150,12 @@ public:
         }
 
         switch (Event.Type) {
-        case mca::HWInstructionEvent::GenericEventType::Ready: {
+        //case mca::HWInstructionEvent::GenericEventType::Dispatched: {
+        // We (ab-)use the LastGenericEventType in the FetchDelay stage to
+        // notify of an event whenever the instruction is fetch. This way, the
+        // cycle count in Binja shows the total instruction cycle count 
+        // including the fetch and dispatch cost.
+        case mca::HWInstructionEvent::GenericEventType::LastGenericEventType : {
             BridgeRef.CountStore[index].CycleReady = CurrentCycle;
         }
         case mca::HWInstructionEvent::GenericEventType::Executed: {


### PR DESCRIPTION
This stage can be inserted between any other stages in the pipeline to introduce a latency penalty to instructions. The stage should behave transparently to the other stages except for the added cycle penalty. This means the stage will accept new instructions (`isAvailable() == true`) whenever the next stage is ready to accept new instructions. It will queue up these instructions and pass them to the next stage after holding them for a number of cycles. We will use this to add the branch misprediction latency later.