### PR TITLE
Add naive branch predictor unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(_MCAVIEWS_SOURCE_FILES
 set(_CUSTOMHW_SOURCE_FILES
     CustomHWUnits/CustomSourceMgr.cpp
     CustomHWUnits/MCADLSUnit.cpp
+    CustomHWUnits/NaiveBranchPredictorUnit.cpp
    )
 
 set(_CUSTOM_STAGES_SOURCE_FILES
@@ -118,6 +119,7 @@ set(_SOURCE_FILES
     ${_CUSTOM_STAGES_SOURCE_FILES}
     ${_BROKERS_SOURCE_FILES}
     MCAWorker.cpp
+    MetadataCategories.cpp
     PipelinePrinter.cpp
     )
 

--- a/CustomHWUnits/AbstractBranchPredictorUnit.h
+++ b/CustomHWUnits/AbstractBranchPredictorUnit.h
@@ -1,0 +1,26 @@
+#ifndef LLVM_MCAD_ABSTRACT_BRANCH_PREDICTOR_UNIT_H
+#define LLVM_MCAD_ABSTRACT_BRANCH_PREDICTOR_UNIT_H
+
+#include <optional>
+#include "llvm/MCA/Instruction.h"
+#include "llvm/MCA/HardwareUnits/HardwareUnit.h"
+#include "MetadataRegistry.h"
+#include "MetadataCategories.h"
+
+namespace llvm {
+namespace mcad {
+
+class AbstractBranchPredictorUnit : public llvm::mca::HardwareUnit {
+
+public:
+    ~AbstractBranchPredictorUnit() {}
+    virtual void recordTakenBranch(MDInstrAddr IA, MDInstrAddr destAddr) = 0;
+    virtual MDInstrAddr predictBranch(MDInstrAddr IA) = 0;
+    virtual unsigned getMispredictionPenalty() = 0;
+
+};
+
+}
+}
+
+#endif

--- a/CustomHWUnits/NaiveBranchPredictorUnit.cpp
+++ b/CustomHWUnits/NaiveBranchPredictorUnit.cpp
@@ -1,0 +1,22 @@
+#include <map>
+#include "CustomHWUnits/NaiveBranchPredictorUnit.h"
+
+namespace llvm {
+namespace mcad {
+
+void NaiveBranchPredictorUnit::recordTakenBranch(MDInstrAddr IA, MDInstrAddr destAddr) {
+    branchHistory[IA] = destAddr;
+}
+
+MDInstrAddr NaiveBranchPredictorUnit::predictBranch(MDInstrAddr IA) {
+    if(branchHistory.find(IA) != branchHistory.end()) {
+        return branchHistory[IA];
+    }
+    // We have no history on this; predict a fall-through branch
+    // FIXME: fix this to use actual branch instruction size, which is likely
+    // larger than one byte.
+    return MDInstrAddr { IA.addr + 1 };
+}
+
+}
+}

--- a/CustomHWUnits/NaiveBranchPredictorUnit.h
+++ b/CustomHWUnits/NaiveBranchPredictorUnit.h
@@ -1,0 +1,28 @@
+#ifndef LLVM_MCAD_NAIVE_BRANCH_PREDICTOR_UNIT_H
+#define LLVM_MCAD_NAIVE_BRANCH_PREDICTOR_UNIT_H
+
+#include <map>
+#include "CustomHWUnits/AbstractBranchPredictorUnit.h"
+
+namespace llvm {
+namespace mcad {
+
+class NaiveBranchPredictorUnit : public AbstractBranchPredictorUnit {
+    unsigned mispredictionPenalty;
+    std::map<MDInstrAddr, MDInstrAddr> branchHistory = {};
+
+public:
+    NaiveBranchPredictorUnit(unsigned mispredictionPenalty = 20) : mispredictionPenalty(mispredictionPenalty) {};
+
+    void recordTakenBranch(MDInstrAddr IA, MDInstrAddr destAddr) override;
+    MDInstrAddr predictBranch(MDInstrAddr IA) override;
+    unsigned getMispredictionPenalty() override {
+        return mispredictionPenalty;
+    }
+
+};
+
+}
+}
+
+#endif

--- a/CustomStages/MCADFetchDelayStage.cpp
+++ b/CustomStages/MCADFetchDelayStage.cpp
@@ -1,5 +1,11 @@
-#include <iostream>
 #include "CustomStages/MCADFetchDelayStage.h"
+#include "MetadataCategories.h"
+#include "llvm/Support/Debug.h"
+#define DEBUG_TYPE "llvm-mca"
+
+#include <iostream>
+#include <iomanip>
+#include <optional>
 
 namespace llvm {
 namespace mcad {
@@ -34,11 +40,35 @@ llvm::Error MCADFetchDelayStage::execute(llvm::mca::InstRef &IR) {
     const llvm::MCInstrDesc &MCID = MCII.get(I->getOpcode());
     bool immediatelyExecute = true;
     unsigned delayCyclesLeft = 0;
-    if(MCID.isBranch()) {
-        // delayed, will have to wait
-        delayCyclesLeft = 100;
+    std::optional<MDInstrAddr> instrAddr = getMDInstrAddrForInstr(MD, IR);
+    // Check if previous instruction was a branch, and if so if the predicted
+    // branch target matched what we ended up executing
+    if(predictedNextInstrAddr.has_value() && instrAddr.has_value()) {
+        if(previousInstrAddr.has_value()) {
+            BPU.recordTakenBranch(*previousInstrAddr, *instrAddr);
+        }
+        if(*predictedNextInstrAddr != *instrAddr) {
+            // Previous prediction was wrong; this instruction will have extra
+            // latency due to misprediction.
+            delayCyclesLeft += BPU.getMispredictionPenalty();
+            LLVM_DEBUG(dbgs() << "[MCAD FetchDelayStage] Previous branch at "); 
+            LLVM_DEBUG(dbgs().write_hex(instrAddr->addr));
+            LLVM_DEBUG(dbgs() << " mispredicted, delaying next instruction by " 
+                       << delayCyclesLeft << "cycle(s).\n");
+        } else {
+            LLVM_DEBUG(dbgs() << "[MCAD FetchDelayStage] Previous branch at ");
+            LLVM_DEBUG(dbgs().write_hex(instrAddr->addr));
+            LLVM_DEBUG(dbgs() << " predicted correctly.\n" );
+        }
+    }
+    // Update branch prediction state
+    if(MCID.isBranch() && instrAddr.has_value()) {
+        predictedNextInstrAddr = BPU.predictBranch(*instrAddr);
+    } else {
+        predictedNextInstrAddr = std::nullopt;
     }
     instrQueue.emplace_back(DelayedInstr { delayCyclesLeft, IR });
+    previousInstrAddr = instrAddr;
     // if the instruction is not delayed, execute it immediately (it will
     // have a delayCyclesLeft of 0 and be at the top of the queue)
     return forwardDueInstrs();

--- a/CustomStages/MCADFetchDelayStage.cpp
+++ b/CustomStages/MCADFetchDelayStage.cpp
@@ -54,7 +54,7 @@ llvm::Error MCADFetchDelayStage::execute(llvm::mca::InstRef &IR) {
             LLVM_DEBUG(dbgs() << "[MCAD FetchDelayStage] Previous branch at "); 
             LLVM_DEBUG(dbgs().write_hex(instrAddr->addr));
             LLVM_DEBUG(dbgs() << " mispredicted, delaying next instruction by " 
-                       << delayCyclesLeft << "cycle(s).\n");
+                       << delayCyclesLeft << " cycle(s).\n");
         } else {
             LLVM_DEBUG(dbgs() << "[MCAD FetchDelayStage] Previous branch at ");
             LLVM_DEBUG(dbgs().write_hex(instrAddr->addr));

--- a/MCAWorker.cpp
+++ b/MCAWorker.cpp
@@ -182,7 +182,7 @@ std::unique_ptr<mca::Pipeline> MCAWorker::createDefaultPipeline() {
                                           MCAPO.StoreQueueSize,
                                           MCAPO.AssumeNoAlias, &MDRegistry);
   auto HWS = std::make_unique<Scheduler>(SM, *LSU);
-  auto BPU = std::make_unique<NaiveBranchPredictorUnit>(100);
+  auto BPU = std::make_unique<NaiveBranchPredictorUnit>(20);
 
   // Create the pipeline stages.
   auto Fetch = std::make_unique<EntryStage>(SrcMgr);
@@ -227,7 +227,7 @@ std::unique_ptr<mca::Pipeline> MCAWorker::createInOrderPipeline() {
   auto LSU = std::make_unique<MCADLSUnit>(SM, MCAPO.LoadQueueSize,
                                           MCAPO.StoreQueueSize,
                                           MCAPO.AssumeNoAlias, &MDRegistry);
-  auto BPU = std::make_unique<NaiveBranchPredictorUnit>(100);
+  auto BPU = std::make_unique<NaiveBranchPredictorUnit>(20);
 
   // Create the pipeline stages.
   auto Entry = std::make_unique<EntryStage>(SrcMgr);

--- a/MetadataCategories.cpp
+++ b/MetadataCategories.cpp
@@ -1,0 +1,21 @@
+#include "llvm/MCA/Instruction.h"
+#include <optional>
+#include "MetadataRegistry.h"
+#include "MetadataCategories.h"
+
+namespace llvm {
+namespace mcad {
+
+std::optional<MDInstrAddr> getMDInstrAddrForInstr(MetadataRegistry &MD, const llvm::mca::InstRef &IR) {
+    const llvm::mca::Instruction *I = IR.getInstruction();
+    auto instrId = I->getIdentifier();
+    if (instrId.has_value()) {
+        auto &Registry = MD[llvm::mcad::MD_InstrAddr];
+        auto instrAddr = Registry.get<MDInstrAddr>(*instrId);
+        return instrAddr;
+    }
+    return std::nullopt;
+}
+
+}
+}

--- a/MetadataCategories.h
+++ b/MetadataCategories.h
@@ -22,6 +22,21 @@ MD_BinaryRegionMarkers
 
 };
 
+struct MDInstrAddr {
+    unsigned long long addr;
+    const bool operator<(const MDInstrAddr &b) const {
+        return addr < b.addr;
+    }
+    const bool operator==(const MDInstrAddr &b) const {
+        return addr == b.addr;
+    }
+    const bool operator!=(const MDInstrAddr &b) const {
+        return addr != b.addr;
+    }
+};
+
+std::optional<MDInstrAddr> getMDInstrAddrForInstr(MetadataRegistry &MD, const llvm::mca::InstRef &IR);
+
 } // end namespace mcad
 } // end namespace llvm
 #endif

--- a/plugins/vivisect-broker/Broker.cpp
+++ b/plugins/vivisect-broker/Broker.cpp
@@ -40,6 +40,7 @@ using namespace mcad;
 // Needed so the TypeID of the shared library and main executable refer to the
 // same type.
 extern template class Any::TypeId<MDMemoryAccess>;
+extern template class Any::TypeId<MDInstrAddr>;
 
 class EmulatorService final : public Emulator::Service {
   grpc::Status RecordEmulatorActions(grpc::ServerContext *ctxt,
@@ -143,7 +144,7 @@ class VivisectBroker : public Broker {
               IndexMap[i] = TotalNumTraces;
 
               auto &InstrAddrCat = Registry[MD_InstrAddr];
-              InstrAddrCat[TotalNumTraces] = insn.addr();
+              InstrAddrCat[TotalNumTraces] = MDInstrAddr { insn.addr() };
 
               if (insn.has_memory_access()) {
                   auto MemAccess = insn.memory_access();


### PR DESCRIPTION
- Create new `MDInstrAddr` type to capture addresses of instructions as metadata.
- Add abstract branch predictor interface
- Add first naive branch predictor; this will always predict that a branch will go where it most recently went. For simple loops this is already good since we will only break out of the loop once at the end of it

Works with the `vivisect` Broker only as other brokers don't add instruction address metadata currently. Look for messages like this in the debug output to see it in action:

```
[MCAD FetchDelayStage] Previous branch at bfca0 predicted correctly.
[MCAD FetchDelayStage] Previous branch at bfca0 mispredicted, delaying next instruction by 20 cycle(s).
```