### PR TITLE
Simulate a multi-level cache

### DIFF
--- a/CustomHWUnits/Cache.h
+++ b/CustomHWUnits/Cache.h
@@ -1,0 +1,125 @@
+#ifndef LLVM_MCAD_CACHE_H
+#define LLVM_MCAD_CACHE_H
+
+#include "CustomHWUnits/AbstractBranchPredictorUnit.h"
+#include "MetadataCategories.h"
+#include <map>
+#include <memory>
+
+namespace llvm {
+namespace mcad {
+
+class Cache {
+private:
+  /// Size of the cache in number of bytes.
+  unsigned size = 2048;
+  /// Number of bytes in a cache line.
+  unsigned lineSize = 64;
+  /// Number of lines in the cache
+  unsigned numLines;
+  /// Number of ways in the cache.
+  unsigned numWays = 2;
+  /// Number of the sets in the cache.
+  unsigned numSets;
+  /// Latency to access the cache.
+  unsigned latency = 2;
+
+  std::vector<std::vector<MDInstrAddr>> table;
+  std::unique_ptr<Cache> nextLevelCache;
+
+protected:
+    // A protected constructor to allow for the creation of a memory object.
+    Cache() = default;
+
+public:
+  Cache(unsigned size, unsigned numWays, std::unique_ptr<Cache> nextLevelCache)
+      : size(size), numWays(numWays), numLines(size / lineSize),
+        numSets(numLines / numWays),
+        table(numSets, std::vector<MDInstrAddr>(numWays)),
+        nextLevelCache(std::move(nextLevelCache)) {
+            assert(size % lineSize == 0);
+            assert(nextLevelCache != nullptr);
+        };
+
+  /// Loads the cacheline from the cache.
+  /// If the cacheline is not in the cache, we will evict an entry and load the cacheline from the next level.
+  virtual unsigned load(MDInstrAddr IA) {
+    unsigned rtn = latency;
+    MDInstrAddr* entry = getEntry(IA);
+    if (entry == nullptr) {
+      entry = evictEntry(IA);
+      *entry = getCachelineAddress(IA);
+      rtn += nextLevelCache->load(IA);
+    }
+    return rtn;
+  }
+
+  /// Write the address to the cache and write-through to the next level.
+  /// If there is no existing entry, we will evict an entry and replace it with the new cacheline.
+  virtual unsigned store(MDInstrAddr IA) {
+    MDInstrAddr* entry = getEntry(IA);
+    if (entry == nullptr) {
+      entry = evictEntry(IA);
+      *entry = getCachelineAddress(IA);
+    } 
+    return latency + nextLevelCache->store(IA); 
+  }
+
+  /// Return the entry if it is in the cache, otherwise return nullptr.
+  ///
+  /// Since we are only simulating the latency, we can simply return the address of
+  /// the cacheline and omit the data.
+  virtual MDInstrAddr* getEntry(MDInstrAddr IA) {
+    // Check if the address is in the cache
+    unsigned setIndex = getSetIndex(IA);
+    for (auto &way : table[setIndex]) {
+      if (way.addr == IA.addr) {
+        return &way;
+      }
+    }
+  }
+
+  /// Find an entry to evict and returns the evicted cacheline.
+  ///
+  /// For simplicity, we will randomly evict an entry in the set if the set if full.
+  virtual MDInstrAddr* evictEntry(MDInstrAddr IA) {
+    unsigned setIndex = getSetIndex(IA);
+    // Attempt to find an empty entry.
+    for (auto &way : table[setIndex]) {
+      if (way.addr == 0) {
+        return &way;
+      }
+    }
+
+    // Evict a random entry.
+    unsigned wayIndex = rand() % numWays;
+    return &table[setIndex][wayIndex];
+  }
+
+  /// Return the cacheline-agligned address.
+  MDInstrAddr getCachelineAddress(MDInstrAddr IA) {
+    MDInstrAddr rtn = IA;
+    rtn.addr -= rtn.addr % lineSize;
+    return rtn;
+  }
+
+  /// Returns the the index of the set that the address maps to.
+  unsigned getSetIndex(MDInstrAddr IA) { return getCachelineAddress(IA).addr % numSets; }
+};
+
+/// A simple memory object that simulates a memory with a fixed load/store latency.
+class Memory : public Cache {
+public:
+  Memory(unsigned latency) : Cache(), latency(latency) {}
+
+  unsigned load(MDInstrAddr IA) override { return latency; }
+  unsigned store(MDInstrAddr IA) override { return latency; }
+
+private:
+  unsigned latency = 300;
+};
+
+} // namespace mcad
+} // namespace llvm
+
+#endif /* LLVM_MCAD_CACHE_H */

--- a/CustomStages/MCADFetchDelayStage.cpp
+++ b/CustomStages/MCADFetchDelayStage.cpp
@@ -51,6 +51,11 @@ llvm::Error MCADFetchDelayStage::execute(llvm::mca::InstRef &IR) {
     std::optional<unsigned> instrSize = MCID.getSize(); 
     assert(MCID.getSize() > 0);
 
+    // fetch instruction from the cache
+    if(CU.has_value()) {
+        delayCyclesLeft += CU->load(*instrAddr);
+    }
+
     // Check if previous instruction was a branch, and if so if the predicted
     // branch target matched what we ended up executing
     if(predictedBranchDirection.has_value() && instrAddr.has_value() && previousInstrAddr.has_value() && previousInstrSize.has_value()) {

--- a/CustomStages/MCADFetchDelayStage.h
+++ b/CustomStages/MCADFetchDelayStage.h
@@ -10,6 +10,7 @@
 #include "llvm/MCA/SourceMgr.h"
 #include "llvm/MCA/Stages/Stage.h"
 #include "CustomHWUnits/AbstractBranchPredictorUnit.h"
+#include "CustomHWUnits/Cache.h"
 #include "MetadataRegistry.h"
 
 #include <vector>
@@ -39,13 +40,19 @@ class MCADFetchDelayStage : public llvm::mca::Stage {
     // there is a mismatch.
     // Non-branch instructions set this member to nullopt.
     std::optional<AbstractBranchPredictorUnit::BranchDirection> predictedBranchDirection = std::nullopt;
+
+    // The memory cache unit.
+    std::optional<CacheUnit> CU = std::nullopt;
     
     // Stores the address and size of the last executed instruction.
     std::optional<MDInstrAddr> previousInstrAddr = std::nullopt;
     std::optional<unsigned> previousInstrSize = std::nullopt;
 
 public:
-    MCADFetchDelayStage(const llvm::MCInstrInfo &MCII, MetadataRegistry &MD, AbstractBranchPredictorUnit &BPU) : MCII(MCII), MD(MD), BPU(BPU) {}
+    MCADFetchDelayStage(const llvm::MCInstrInfo &MCII, MetadataRegistry &MD,
+                        AbstractBranchPredictorUnit &BPU,
+                        std::optional<CacheUnit> CU = std::nullopt)
+        : MCII(MCII), MD(MD), BPU(BPU), CU(std::move(CU)) {}
 
     bool hasWorkToComplete() const override;
     bool isAvailable(const llvm::mca::InstRef &IR) const override;

--- a/MCAWorker.cpp
+++ b/MCAWorker.cpp
@@ -259,7 +259,6 @@ std::unique_ptr<mca::Pipeline> MCAWorker::createDefaultPipeline() {
                                           MCAPO.AssumeNoAlias, &MDRegistry, L1D);
   auto HWS = std::make_unique<Scheduler>(SM, *LSU);
   auto BPU = std::make_unique<SkylakeBranchUnit>(20);
-  auto [L1I, L1D] = buildCache();
 
   // Create the pipeline stages.
   auto Fetch = std::make_unique<EntryStage>(SrcMgr);
@@ -306,7 +305,6 @@ std::unique_ptr<mca::Pipeline> MCAWorker::createInOrderPipeline() {
                                           MCAPO.StoreQueueSize,
                                           MCAPO.AssumeNoAlias, &MDRegistry);
   auto BPU = std::make_unique<SkylakeBranchUnit>(20);
-  auto [L1I, L1D] = buildCache();
 
   // Create the pipeline stages.
   auto Entry = std::make_unique<EntryStage>(SrcMgr);

--- a/MCAWorker.cpp
+++ b/MCAWorker.cpp
@@ -253,9 +253,10 @@ std::unique_ptr<mca::Pipeline> MCAWorker::createDefaultPipeline() {
   // Create the hardware units defining the backend.
   auto RCU = std::make_unique<RetireControlUnit>(SM);
   auto PRF = std::make_unique<RegisterFile>(SM, MRI, MCAPO.RegisterFileSize);
+  auto [L1I, L1D] = buildCache();
   auto LSU = std::make_unique<MCADLSUnit>(SM, MCAPO.LoadQueueSize,
                                           MCAPO.StoreQueueSize,
-                                          MCAPO.AssumeNoAlias, &MDRegistry);
+                                          MCAPO.AssumeNoAlias, &MDRegistry, L1D);
   auto HWS = std::make_unique<Scheduler>(SM, *LSU);
   auto BPU = std::make_unique<SkylakeBranchUnit>(20);
   auto [L1I, L1D] = buildCache();
@@ -299,6 +300,7 @@ std::unique_ptr<mca::Pipeline> MCAWorker::createInOrderPipeline() {
   const MCSchedModel &SM = STI.getSchedModel();
   const MCRegisterInfo &MRI = TheMCA.getMCRegisterInfo();
 
+  auto [L1I, L1D] = buildCache();
   auto PRF = std::make_unique<RegisterFile>(SM, MRI, MCAPO.RegisterFileSize);
   auto LSU = std::make_unique<MCADLSUnit>(SM, MCAPO.LoadQueueSize,
                                           MCAPO.StoreQueueSize,

--- a/MCAWorker.cpp
+++ b/MCAWorker.cpp
@@ -115,6 +115,70 @@ static cl::opt<unsigned>
                          cl::desc("Size of the simulated branch history table for branch prediction"),
                          cl::init(10U));
 
+static cl::opt<bool>
+  EnableCache("enable-cache",
+                          cl::desc("Simuate the memory cache hierachy"),
+                          cl::init(true));
+
+static cl::opt<unsigned>
+  NumWays("num-ways",
+          cl::desc("Number of ways for all the caches"),
+          cl::init(4U));
+
+static cl::opt<unsigned>
+  L1ISize("l1i-size",
+          cl::desc("Size of the L1 Instruction cache"),
+          cl::init(64 * 1024U));
+
+static cl::opt<unsigned>
+  L1DSize("l1d-size",
+          cl::desc("Size of the L1 Data cache"),
+          cl::init(64 * 1024U));
+
+static cl::opt<unsigned>
+  L1Latency("l1-latency",
+          cl::desc("Latency for accessing the L3 cache"),
+          cl::init(3U));
+
+static cl::opt<unsigned>
+  L2Size("l2-size",
+          cl::desc("Size of the L2 cache"),
+          cl::init(512 * 1024U));
+
+static cl::opt<unsigned>
+  L2Latency("l2-latency",
+          cl::desc("Latency for accessing the L3 cache"),
+          cl::init(10U));
+
+static cl::opt<unsigned>
+  L3Size("l3-size",
+          cl::desc("Size of the L3 cache"),
+          cl::init(4 * 1024 * 1024U));
+
+static cl::opt<unsigned>
+  L3Latency("l3-latency",
+          cl::desc("Latency for accessing the L3 cache"),
+          cl::init(30U));
+
+static cl::opt<unsigned>
+  MemoryLatency("memory-latency",
+          cl::desc("Latency for accessing the main memory"),
+          cl::init(300U));
+
+namespace {
+std::tuple<std::optional<CacheUnit>, std::optional<CacheUnit>> buildCache() {
+  if (!EnableCache)
+    return std::make_tuple(std::nullopt, std::nullopt);
+
+  auto Memory = std::make_shared<MemoryUnit>(MemoryLatency);
+  auto L3 = std::make_shared<CacheUnit>(L3Size, NumWays, Memory, L3Latency);
+  auto L2 = std::make_shared<CacheUnit>(L2Size, NumWays, L3, L2Latency);
+  CacheUnit L1D(L1DSize, NumWays, L2, L1Latency);
+  CacheUnit L1I(L1ISize, NumWays, L2, L1Latency);
+  return std::make_tuple(L1I, L1D);
+}
+} // anonymous namespace
+
 void BrokerFacade::setBroker(std::unique_ptr<Broker> &&B) {
   Worker.TheBroker = std::move(B);
 }
@@ -194,10 +258,11 @@ std::unique_ptr<mca::Pipeline> MCAWorker::createDefaultPipeline() {
                                           MCAPO.AssumeNoAlias, &MDRegistry);
   auto HWS = std::make_unique<Scheduler>(SM, *LSU);
   auto BPU = std::make_unique<SkylakeBranchUnit>(20);
+  auto [L1I, L1D] = buildCache();
 
   // Create the pipeline stages.
   auto Fetch = std::make_unique<EntryStage>(SrcMgr);
-  auto FetchDelay = std::make_unique<MCADFetchDelayStage>(MCII, MDRegistry, *BPU);
+  auto FetchDelay = std::make_unique<MCADFetchDelayStage>(MCII, MDRegistry, *BPU, L1I);
   auto Dispatch = std::make_unique<DispatchStage>(STI, MRI, MCAPO.DispatchWidth,
                                                   *RCU, *PRF);
   auto Execute =
@@ -239,10 +304,11 @@ std::unique_ptr<mca::Pipeline> MCAWorker::createInOrderPipeline() {
                                           MCAPO.StoreQueueSize,
                                           MCAPO.AssumeNoAlias, &MDRegistry);
   auto BPU = std::make_unique<SkylakeBranchUnit>(20);
+  auto [L1I, L1D] = buildCache();
 
   // Create the pipeline stages.
   auto Entry = std::make_unique<EntryStage>(SrcMgr);
-  auto FetchDelay = std::make_unique<MCADFetchDelayStage>(MCII, MDRegistry, *BPU);
+  auto FetchDelay = std::make_unique<MCADFetchDelayStage>(MCII, MDRegistry, *BPU, L1I);
   auto InOrderIssue = std::make_unique<InOrderIssueStage>(STI, *PRF, *CB, *LSU);
   auto StagePipeline = std::make_unique<Pipeline>();
 


### PR DESCRIPTION
By default, we simulate a 3-level memory cache with a dedicated L1 instruction cache. Each cache is a 4-way set associative cache with a 64-bit cache line.
The delay introduced by the cache is simulated in the `MCADFetchDelayStage` for the instruction cache and `MCADLSUnit` for the data cache.