### PR TITLE
remove MIPS-specific method from MCStreamer

### DIFF
--- a/Brokers/AsmUtils/CodeRegionGenerator.cpp
+++ b/Brokers/AsmUtils/CodeRegionGenerator.cpp
@@ -63,7 +63,6 @@ public:
   void emitZerofill(MCSection *Section, MCSymbol *Symbol = nullptr,
                     uint64_t Size = 0, Align ByteAlignment = Align(1),
                     SMLoc Loc = SMLoc()) override {}
-  void emitGPRel32Value(const MCExpr *Value) override {}
   void BeginCOFFSymbolDef(const MCSymbol *Symbol) {}
   void EmitCOFFSymbolStorageClass(int StorageClass) {}
   void EmitCOFFSymbolType(int Type) {}


### PR DESCRIPTION
Fixes #42.

Root cause: Upstream removed the MIPS-specific `emitGPRel32Value()` method from `MCStramer` in commit [`0c5d7d`](https://github.com/llvm/llvm-project/commit/0c5d709301b25b588ccb9cfb4d9c219cc5bdcaf1). Before this change, we overrode that method

Since we don't currently target MIPS and the function was empty anyways, this PR just removes it to restore compatibility with upstream.